### PR TITLE
Fix WP test library path

### DIFF
--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Run PHPUnit
         run: vendor/bin/phpunit --configuration phpunit.xml.dist --testdox
         env:
-          WP_TESTS_DIR: /tmp/wordpress-tests-lib
+          WP_TESTS_DIR: /tmp/wordpress-tests-lib/includes
 
       # 7️⃣  Enforce WordPress coding standards
       - name: Run PHPCS


### PR DESCRIPTION
## Summary
- fix WP_TESTS_DIR path in plugin-ci workflow so bootstrap can find WordPress tests

## Testing
- `apt-get update`
- `apt-get install -y php-cli php-mbstring unzip`
- `php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6858fb1818cc83338ef21dd00c0e4ae8