### PR TITLE
Fix activation hooks and composer paths

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,12 @@
     "yoast/phpunit-polyfills": "^4.0"
   },
   "scripts": {
-    "lint": "phpcs --standard=WordPress --extensions=php stoneflow",
+    "lint": "phpcs --standard=WordPress --extensions=php stoneflow.php includes",
     "test": "phpunit"
   },
   "autoload": {
     "psr-4": {
-      "StoneFlow\\": "stoneflow/"
+      "StoneFlow\\": "includes/"
     }
   },
   "config": {

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -27,4 +27,3 @@ function stoneflow_create_clients_table() {
 	require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 	dbDelta( $sql );
 }
-register_activation_hook( __FILE__, 'stoneflow_create_clients_table' );

--- a/stoneflow.php
+++ b/stoneflow.php
@@ -21,11 +21,13 @@ require_once STONEFLOW_DIR . 'includes/class-service-queue.php';
 require_once STONEFLOW_DIR . 'includes/class-stone-ai.php';
 require_once STONEFLOW_DIR . 'includes/class-admin-notes.php';
 require_once STONEFLOW_DIR . 'includes/class-service-purchase.php';
+require_once STONEFLOW_DIR . 'includes/functions.php';
 
 register_activation_hook( __FILE__, function () {
     global $wpdb;
     StoneFlow\create_services_table( $wpdb );
 } );
+register_activation_hook( __FILE__, 'stoneflow_create_clients_table' );
 
 
 // Activation: Create custom tables


### PR DESCRIPTION
## Summary
- update composer autoload and lint path
- move client table activation hook to main plugin

## Testing
- `composer lint` *(fails: style violations)*
- `composer test` *(fails: WP test constants not defined)*


------
https://chatgpt.com/codex/tasks/task_e_68590b549fec8333b1cfda4c864f980f